### PR TITLE
Add simple translation framework

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import platform
 from logging.handlers import RotatingFileHandler
+from utils.translator import translator
 
 # ロガーの設定
 logging.basicConfig(
@@ -266,6 +267,9 @@ def main():
         # 設定の初期化
         app_settings = AppSettings()
         logger.info("AppSettings initialized")
+
+        # 翻訳の初期化
+        translator.set_language(app_settings.get_setting("language", "en"))
 
         # コントローラーの初期化
         controller = AppController(app_settings)

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,9 @@
+{
+  "language_name": "English",
+  "language_label": "Language",
+  "theme_label": "Theme",
+  "width_label": "Width",
+  "height_label": "Height",
+  "fullscreen_label": "Start in fullscreen",
+  "auto_save": "Enable auto save"
+}

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,0 +1,9 @@
+{
+  "language_name": "Español",
+  "language_label": "Idioma",
+  "theme_label": "Tema",
+  "width_label": "Ancho",
+  "height_label": "Altura",
+  "fullscreen_label": "Iniciar en pantalla completa",
+  "auto_save": "Habilitar guardado automático"
+}

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -1,0 +1,9 @@
+{
+  "language_name": "日本語",
+  "language_label": "言語",
+  "theme_label": "テーマ",
+  "width_label": "幅",
+  "height_label": "高さ",
+  "fullscreen_label": "全画面表示で起動",
+  "auto_save": "自動保存を有効にする"
+}

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .translator import translator

--- a/utils/translator.py
+++ b/utils/translator.py
@@ -1,0 +1,52 @@
+import os
+import json
+
+class Translator:
+    def __init__(self, language='en'):
+        self.language = language
+        self.translations = {}
+        self._load(language)
+
+    @property
+    def translations_dir(self):
+        return os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'translations')
+
+    def _load(self, language):
+        path = os.path.join(self.translations_dir, f'{language}.json')
+        if not os.path.exists(path):
+            path = os.path.join(self.translations_dir, 'en.json')
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                self.translations = json.load(f)
+            self.language = language
+        except Exception:
+            self.translations = {}
+            self.language = language
+
+    def set_language(self, language):
+        self._load(language)
+
+    def translate(self, key):
+        return self.translations.get(key, key)
+
+    def get_language_name(self, language):
+        path = os.path.join(self.translations_dir, f'{language}.json')
+        if os.path.exists(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                return data.get('language_name', language)
+            except Exception:
+                pass
+        return language
+
+    def get_available_languages(self):
+        languages = {}
+        if os.path.isdir(self.translations_dir):
+            for filename in os.listdir(self.translations_dir):
+                if filename.endswith('.json'):
+                    code = os.path.splitext(filename)[0]
+                    languages[code] = self.get_language_name(code)
+        return languages
+
+translator = Translator()

--- a/views/settings_view.py
+++ b/views/settings_view.py
@@ -68,14 +68,16 @@ class SettingsView(QWidget):
         app_layout = QFormLayout()
 
         self.language_combo = QComboBox()
-        self.language_combo.addItems(["日本語", "English"])
-        app_layout.addRow("言語:", self.language_combo)
+        from utils.translator import translator
+        for code, name in translator.get_available_languages().items():
+            self.language_combo.addItem(name, userData=code)
+        app_layout.addRow(translator.translate("language_label") + ":", self.language_combo)
 
         self.theme_combo = QComboBox()
         self.theme_combo.addItems(["Windows95", "Modern", "Dark"])
-        app_layout.addRow("テーマ:", self.theme_combo)
+        app_layout.addRow(translator.translate("theme_label") + ":", self.theme_combo)
 
-        self.auto_save_check = QCheckBox("自動保存を有効にする")
+        self.auto_save_check = QCheckBox(translator.translate("auto_save"))
         app_layout.addRow(self.auto_save_check)
 
         app_group.setLayout(app_layout)
@@ -88,14 +90,15 @@ class SettingsView(QWidget):
         self.width_spin = QSpinBox()
         self.width_spin.setRange(800, 2560)
         self.width_spin.setValue(1080)
-        window_layout.addRow("幅:", self.width_spin)
+        from utils.translator import translator
+        window_layout.addRow(translator.translate("width_label") + ":", self.width_spin)
 
         self.height_spin = QSpinBox()
         self.height_spin.setRange(600, 1440)
         self.height_spin.setValue(720)
-        window_layout.addRow("高さ:", self.height_spin)
+        window_layout.addRow(translator.translate("height_label") + ":", self.height_spin)
 
-        self.fullscreen_check = QCheckBox("全画面表示で起動")
+        self.fullscreen_check = QCheckBox(translator.translate("fullscreen_label"))
         window_layout.addRow(self.fullscreen_check)
 
         window_group.setLayout(window_layout)
@@ -250,7 +253,9 @@ class SettingsView(QWidget):
         try:
             # 一般設定
             language = self.app_settings.get_setting("language", "ja")
-            self.language_combo.setCurrentText("日本語" if language == "ja" else "English")
+            index = self.language_combo.findData(language)
+            if index != -1:
+                self.language_combo.setCurrentIndex(index)
 
             theme = self.app_settings.get_setting("theme", "light")
             if theme in ["Windows95", "Modern", "Dark"]:
@@ -331,8 +336,13 @@ class SettingsView(QWidget):
 
         try:
             # 一般設定
-            language = "ja" if self.language_combo.currentText() == "日本語" else "en"
-            self.app_settings.set_setting("language", language)
+            language = self.language_combo.currentData()
+            from utils.translator import translator
+            if language:
+                self.app_settings.set_setting("language", language)
+                translator.set_language(language)
+            else:
+                self.app_settings.set_setting("language", "en")
             self.app_settings.set_setting("theme", self.theme_combo.currentText())
 
             # ウィンドウ設定


### PR DESCRIPTION
## Summary
- set up JSON translation dictionaries
- add a translator utility for loading strings
- initialize translations in `main.py`
- update Settings view to support multiple languages dynamically

## Testing
- `pytest -q` *(fails: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68495121fe4483228792b0c2b32bd473