### PR TITLE
Stop exporting calculated stats

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -3379,14 +3379,13 @@ class AppController(QObject):
                 if slot_id and equipment_id:
                     export_data['modules'][slot_id] = equipment_id
             
-            # 性能計算
+            # 性能計算（結果は内部表示用のみで、出力には含めない）
             try:
                 from utils.stats_calculator import StatsCalculator
                 calculator = StatsCalculator(self)
-                export_data['calculated_stats'] = calculator.calculate_design_stats(export_data)
+                _ = calculator.calculate_design_stats(export_data)
             except Exception as e:
                 logger.warning(f"性能計算エラー ({design_id}): {e}")
-                export_data['calculated_stats'] = {}
             
             return export_data
             

--- a/exporters/hoi4_exporter.py
+++ b/exporters/hoi4_exporter.py
@@ -124,7 +124,6 @@ class HOI4Exporter(BaseExporter):
         hull_id = design_data['hull_id']
         modules = design_data.get('modules', {})
         upgrades = design_data.get('upgrades', {})
-        stats = design_data.get('calculated_stats', {})
         
         lines = []
         lines.append("    create_equipment_variant = {")
@@ -151,13 +150,7 @@ class HOI4Exporter(BaseExporter):
             lines.append("        }")
         
         lines.append("    }")
-        
-        # 性能をコメントで追加
-        if self.include_stats_comments and stats:
-            stats_comment = self._generate_stats_comment(stats)
-            if stats_comment:
-                lines.append(f"    {stats_comment}")
-        
+
         return "\\n".join(lines)
     
     def _generate_equipment_block(self, hull_data: Dict[str, Any]) -> str:

--- a/views/hoi4_export_dialog.py
+++ b/views/hoi4_export_dialog.py
@@ -47,7 +47,6 @@ class HOI4ExportWorker(QThread):
             )
             
             # 設定を適用
-            exporter.include_stats_comments = self.export_config.get('include_stats_comments', True)
             exporter.include_upgrades = self.export_config.get('include_upgrades', True)
             
             results = {
@@ -192,14 +191,13 @@ class HOI4ExportWorker(QThread):
             if slot_id and equipment_id:
                 export_data['modules'][slot_id] = equipment_id
         
-        # 性能計算
+        # 性能計算（内部表示用。結果はエクスポートデータに含めない）
         try:
             calculator = StatsCalculator(self.app_controller)
-            export_data['calculated_stats'] = calculator.calculate_design_stats(export_data)
+            _ = calculator.calculate_design_stats(export_data)
         except Exception as e:
             self.logger.warning(f"性能計算エラー: {e}")
-            export_data['calculated_stats'] = {}
-        
+
         return export_data
 
     def _prepare_hull_for_export(self, hull_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -478,7 +476,6 @@ class HOI4ExportDialog(QDialog):
             'country_tag': self.country_tag_edit.text().strip().upper(),
             'export_designs': self.export_designs_cb.isChecked(),
             'export_hulls': self.export_hulls_cb.isChecked(),
-            'include_stats_comments': self.include_stats_cb.isChecked(),
             'include_upgrades': self.include_upgrades_cb.isChecked(),
             'backup_existing': self.backup_existing_cb.isChecked(),
             'encoding': self.encoding_combo.currentText(),
@@ -536,8 +533,6 @@ class HOI4ExportDialog(QDialog):
                 preview_content.append("            fixed_ship_deck_slot_1 = flush_deck")
                 preview_content.append("        }")
                 preview_content.append("    }")
-                if config['include_stats_comments']:
-                    preview_content.append("    # 性能: 攻撃力: 120, 防御力: 80")
                 preview_content.append("}")
                 preview_content.append("")
             


### PR DESCRIPTION
## Summary
- drop calculated_stats from export output
- keep stat calculation only for internal display

## Testing
- `pytest -q`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_6877a918c26c8322922976c02df35288