### PR TITLE
Update equipment calculation fallback

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -1,5 +1,16 @@
 # 開発ログ
 
+## 2025年7月16日 (水)
+
+### ✅ 計算ロジック更新
+**時刻**: 22:35
+**概要**: 装備JSONから一部ステータスが削除された変更に対応し、計算クラスでフォールバック処理を追加。
+**影響範囲**:
+- utils/equipment_calculators/base_calculator.py
+- utils/equipment_calculators/engine_calculator.py
+
+
+
 ## 2025年7月15日 (火)
 
 ### ✅ プロジェクト構造ドキュメント追加

--- a/utils/equipment_calculators/base_calculator.py
+++ b/utils/equipment_calculators/base_calculator.py
@@ -72,7 +72,7 @@ class BaseEquipmentCalculator(ABC):
             dict: 基本ステータス
         """
         stats = {}
-        
+
         # 装備データから直接ステータスを取得
         status_keys = [
             'lg_attack', 'hg_attack', 'lg_armor_piercing', 'hg_armor_piercing',
@@ -81,15 +81,43 @@ class BaseEquipmentCalculator(ABC):
             'naval_speed', 'manpower', 'fuel_consumption', 'equipment_weight',
             'reliability', 'naval_range', 'max_strength', 'shore_bombardment'
         ]
-        
+
         for key in status_keys:
-            value = equipment_data.get(key, 0.0)
-            if isinstance(value, (int, float)):
-                stats[key] = float(value)
-            else:
-                stats[key] = 0.0
-                
+            stats[key] = self._get_stat_value(equipment_data, key)
+
         return stats
+
+    def _get_stat_value(self, equipment_data: Dict[str, Any], key: str, default: float = 0.0) -> float:
+        """装備データからステータス値を取得（新旧フォーマット両対応）"""
+        # 直接参照
+        value = equipment_data.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        # specific_elements 内
+        value = equipment_data.get('specific_elements', {}).get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        # common 内
+        value = equipment_data.get('common', {}).get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        # エイリアス処理
+        if key == 'equipment_weight':
+            for alias in ['weight', '重量']:
+                alt = equipment_data.get(alias) or equipment_data.get('common', {}).get(alias)
+                if isinstance(alt, (int, float)):
+                    return float(alt)
+
+        if key == 'manpower':
+            for alias in ['personnel', '人員']:
+                alt = equipment_data.get(alias) or equipment_data.get('common', {}).get(alias)
+                if isinstance(alt, (int, float)):
+                    return float(alt)
+
+        return float(default)
     
     @abstractmethod 
     def _calculate_category_stats(self, equipment_data: Dict[str, Any], hull_data: Optional[Dict[str, Any]]) -> Dict[str, float]:

--- a/utils/equipment_calculators/engine_calculator.py
+++ b/utils/equipment_calculators/engine_calculator.py
@@ -56,9 +56,9 @@ class EngineCalculator(BaseEquipmentCalculator):
         """
         speed_stats = {}
         
-        # 機関出力（specific_elementsから取得）
+        # 機関出力
         specific_elements = equipment_data.get('specific_elements', {})
-        engine_power = specific_elements.get('power', 0.0)
+        engine_power = specific_elements.get('power', equipment_data.get('power', 0.0))
         
         # フォールバック：重量ベースで推定
         if engine_power == 0.0:
@@ -98,11 +98,11 @@ class EngineCalculator(BaseEquipmentCalculator):
         consumption_stats = {}
         
         specific_elements = equipment_data.get('specific_elements', {})
-        
+
         # 機関出力から燃料消費を計算
-        engine_power = specific_elements.get('power', 0.0)
-        fuel_capacity = specific_elements.get('fuel_capacity', 0.0)
-        engine_type = specific_elements.get('engine_type', 'HeavyOil')
+        engine_power = specific_elements.get('power', equipment_data.get('power', 0.0))
+        fuel_capacity = specific_elements.get('fuel_capacity', equipment_data.get('fuel_capacity', 0.0))
+        engine_type = specific_elements.get('engine_type', equipment_data.get('engine_type', 'HeavyOil'))
         
         # 機関種別による効率係数
         efficiency_factors = {
@@ -149,7 +149,7 @@ class EngineCalculator(BaseEquipmentCalculator):
         range_stats = {}
         
         specific_elements = equipment_data.get('specific_elements', {})
-        engine_type = specific_elements.get('engine_type', 'HeavyOil')
+        engine_type = specific_elements.get('engine_type', equipment_data.get('engine_type', 'HeavyOil'))
         
         # 機関種別による航続距離効率係数
         range_factors = {
@@ -195,7 +195,7 @@ class EngineCalculator(BaseEquipmentCalculator):
         reliability_stats = {}
         
         # 基本信頼性
-        base_reliability = equipment_data.get('reliability', 0.0)
+        base_reliability = equipment_data.get('reliability', equipment_data.get('specific_elements', {}).get('reliability', 0.0))
         
         # 開発年度による信頼性（技術成熟度）
         dev_year = equipment_data.get('year', 1936)


### PR DESCRIPTION
## Summary
- update equipment calculation helpers to support missing stats in new JSON
- handle power and other fields from both old and new formats
- log development entry for this change

## Testing
- `flake8 .` *(fails: many style violations)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877a98e31c08322965d8fcf0279764a