### PR TITLE
Fix settings input focus issue

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -1359,3 +1359,6 @@ self.coords_file_path = os.path.join(cache_dir, f"{mod_name}_flags_coords.json")
 
 ### 2025-06-11 13:30
 - **パフォーマンス最適化ルール**: 描画処理軽量化の標準化
+### 2025-07-17 10:00
+- 設定画面で入力欄にフォーカスできない不具合を修正
+

--- a/views/settings_view.py
+++ b/views/settings_view.py
@@ -60,6 +60,8 @@ class SettingsView(QWidget):
 
         # スクロールエリア
         scroll_area = QScrollArea()
+        # 入力欄のキー入力がスクロールエリアに奪われないようにする
+        scroll_area.setFocusPolicy(Qt.NoFocus)
         scroll_widget = QWidget()
         scroll_layout = QVBoxLayout(scroll_widget)
 
@@ -114,6 +116,8 @@ class SettingsView(QWidget):
 
         # スクロールエリア
         scroll_area = QScrollArea()
+        # フォーカスが奪われないように設定
+        scroll_area.setFocusPolicy(Qt.NoFocus)
         scroll_widget = QWidget()
         scroll_layout = QVBoxLayout(scroll_widget)
 
@@ -177,6 +181,8 @@ class SettingsView(QWidget):
 
         # スクロールエリア
         scroll_area = QScrollArea()
+        # スクロールエリアがフォーカスを保持しないようにする
+        scroll_area.setFocusPolicy(Qt.NoFocus)
         scroll_widget = QWidget()
         scroll_layout = QVBoxLayout(scroll_widget)
 


### PR DESCRIPTION
## Summary
- ensure scroll areas don't steal focus in SettingsView
- note bug fix in development log

## Testing
- `python -m py_compile views/settings_view.py`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_687b412718448322a1c25fe5651c71ab