### PR TITLE
Fix text input focus issues in scroll areas

### DIFF
--- a/views/design_view.py
+++ b/views/design_view.py
@@ -204,6 +204,9 @@ class DesignView(QWidget):
         # 内部スロットの表示エリア
         internal_slots_scroll = QScrollArea()
         internal_slots_scroll.setWidgetResizable(True)
+        # 入力欄のキー入力がスクロールエリアに奪われないようにする
+        internal_slots_scroll.setFocusPolicy(Qt.NoFocus)
+        internal_slots_scroll.viewport().setFocusPolicy(Qt.NoFocus)
 
         self.internal_slots_container = QWidget()
         self.internal_slots_grid = QGridLayout(self.internal_slots_container)
@@ -218,6 +221,9 @@ class DesignView(QWidget):
         # スロット部分をスクロール可能に
         slots_scroll = QScrollArea()
         slots_scroll.setWidgetResizable(True)
+        # 入力欄のキー入力がスクロールエリアに奪われないようにする
+        slots_scroll.setFocusPolicy(Qt.NoFocus)
+        slots_scroll.viewport().setFocusPolicy(Qt.NoFocus)
         slots_scroll.setWidget(slots_container)
         slots_scroll.setMinimumWidth(400)  # 最小幅を設定
         slots_scroll.setMaximumWidth(600)  # 最大幅を設定
@@ -1449,6 +1455,9 @@ class DesignView(QWidget):
             # スクロールエリアを作成
             scroll_area = QScrollArea()
             scroll_area.setWidgetResizable(True)
+            # 入力欄のキー入力がスクロールエリアに奪われないようにする
+            scroll_area.setFocusPolicy(Qt.NoFocus)
+            scroll_area.viewport().setFocusPolicy(Qt.NoFocus)
             scroll_widget = QWidget()
             scroll_layout = QVBoxLayout(scroll_widget)
 

--- a/views/equipment_form.py
+++ b/views/equipment_form.py
@@ -75,6 +75,9 @@ class EquipmentForm(QWidget):
         # 装備データ入力用スクロールエリア
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
+        # 入力欄のキー入力がスクロールエリアに奪われないようにする
+        scroll_area.setFocusPolicy(Qt.NoFocus)
+        scroll_area.viewport().setFocusPolicy(Qt.NoFocus)
         main_layout.addWidget(scroll_area)
 
         self.form_container = QWidget()

--- a/views/hull_form.py
+++ b/views/hull_form.py
@@ -47,6 +47,9 @@ class HullForm(QWidget):
         # スクロールエリア
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
+        # 入力欄のキー入力がスクロールエリアに奪われないようにする
+        scroll_area.setFocusPolicy(Qt.NoFocus)
+        scroll_area.viewport().setFocusPolicy(Qt.NoFocus)
         main_layout.addWidget(scroll_area)
 
         form_container = QWidget()


### PR DESCRIPTION
## Summary
- ensure scroll areas don't steal focus in DesignView
- do the same for EquipmentForm and HullForm

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_687b9aa68d74832298f8bdef63e6e5f2