### PR TITLE
Fix Apple Silicon text input

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from logging.handlers import RotatingFileHandler
 if platform.system() == "Darwin":  # macOS
     os.environ['QT_MAC_DISABLE_FOREGROUND_APPLICATION_TRANSFORM'] = '1'
     os.environ['QT_LOGGING_RULES'] = 'qt.qpa.input.methods.debug=false'
+    # Apple Silicon環境での文字入力不具合を回避するため
+    os.environ.setdefault('QT_MAC_WANTS_LAYER', '1')
 
 # ロガーの設定
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- set `QT_MAC_WANTS_LAYER` on macOS to enable typing on Apple Silicon

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_687b9be15e548322914d3f75c896e159