### PR TITLE
Improve GitHub Actions workflow for Python

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,9 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'poetry'
+        cache-dependency-path: |
+          pyproject.toml
+          poetry.lock
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- enable built-in Poetry caching in CI by using `actions/setup-python@v5`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb8280de88322adb6843b245acd6d