### PR TITLE
Implement automatic build increment on startup

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -1362,3 +1362,5 @@ self.coords_file_path = os.path.join(cache_dir, f"{mod_name}_flags_coords.json")
 ### 2025-07-17 10:00
 - 設定画面で入力欄にフォーカスできない不具合を修正
 
+### 2025-07-20 10:27
+- 起動時にversion.txtのビルド番号を自動更新する機能を追加

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import sys
 import logging
 import platform
 from logging.handlers import RotatingFileHandler
+from utils.version_manager import increment_build_number
 
 # macOS の Input Method Kit エラーを抑制
 if platform.system() == "Darwin":  # macOS
@@ -194,6 +195,7 @@ def main():
     MVCパターンに従い、コントローラーを通じてアプリケーションを起動します
     """
     logger.info(f"Starting NavalDesignSystem on {platform.system()} {platform.release()}")
+    increment_build_number()
 
     # 依存関係チェック
     if not check_dependencies():

--- a/utils/version_manager.py
+++ b/utils/version_manager.py
@@ -1,0 +1,29 @@
+# Copyright (c) eightman 2005-2025
+# Rights reserved by Furin-lab
+# 動作設計: バージョン管理ユーティリティ
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+VERSION_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "version.txt")
+
+def increment_build_number():
+    """version.txtのビルド番号を1増やす"""
+    version = "0.0.0.00"
+    try:
+        if os.path.exists(VERSION_FILE):
+            with open(VERSION_FILE, "r", encoding="utf-8") as f:
+                version = f.read().strip()
+        parts = version.split('.')
+        if parts and parts[-1].isdigit():
+            width = len(parts[-1])
+            parts[-1] = str(int(parts[-1]) + 1).zfill(width)
+            new_version = '.'.join(parts)
+            with open(VERSION_FILE, "w", encoding="utf-8") as f:
+                f.write(new_version)
+            logger.info(f"Incremented build number: {version} -> {new_version}")
+            return new_version
+    except Exception as e:
+        logger.warning(f"Failed to increment build number: {e}")
+    return version


### PR DESCRIPTION
## Summary
- add `increment_build_number` helper
- call helper at application startup
- log new feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c45614584832286296af1fcf2703f