### PR TITLE
Add fixed sensor slots

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -1390,3 +1390,10 @@ self.coords_file_path = os.path.join(cache_dir, f"{mod_name}_flags_coords.json")
 **概要**: 12cm砲の重砲攻撃力が高すぎる問題を受け、中口径砲の攻撃・貫徹計算と重量人員補正を見直し。
 **影響範囲**:
 - utils/equipment_calculators/gun_calculator.py
+
+### 🚀 デフォルト内部スロット追加
+**時刻**: 19:41
+**概要**: 新規設計時に電探・ソナー・火器管制用の内部スロットを自動生成。既存設計読
+み込みでも内部スロットが無い場合に追加するよう対応。
+**影響範囲**:
+- views/design_view.py

--- a/views/design_view.py
+++ b/views/design_view.py
@@ -716,6 +716,9 @@ class DesignView(QWidget):
             # スロット情報を取得し、開放状況に応じてUIを更新
             self.update_slot_availability()
 
+            # デフォルト内部スロットを自動追加
+            self.ensure_default_internal_slots()
+
         except Exception as e:
             QMessageBox.critical(self, "エラー", f"船体データの設定中にエラーが発生しました: {e}")
 
@@ -1406,6 +1409,44 @@ class DesignView(QWidget):
             import traceback
             traceback.print_exc()
 
+    def ensure_default_internal_slots(self):
+        """内部スロットが空の場合にセンサー系スロットを自動追加"""
+        try:
+            if self.internal_slots:
+                return
+
+            default_sets = [
+                ["small_radar", "large_radar"],
+                ["sonar", "large_sonar"],
+                ["fire_control_system"],
+            ]
+
+            for categories in default_sets:
+                self.add_internal_slot()
+                if not self.internal_slots:
+                    continue
+                slot_info = self.internal_slots[-1]
+                slot_id = slot_info["id"]
+                self.slot_category_selections[slot_id] = categories
+
+                button = slot_info["category_button"]
+                names = [
+                    self.app_controller.get_equipment_display_name(c)
+                    if self.app_controller else c
+                    for c in categories
+                ]
+
+                if len(names) == 1:
+                    button.setText(names[0])
+                else:
+                    button.setText(f"{len(names)}種類選択")
+
+                self.update_equipment_combo(slot_id)
+        except Exception as e:
+            print(f"デフォルト内部スロット追加エラー: {e}")
+            import traceback
+            traceback.print_exc()
+
     def show_category_selection_dialog(self, slot_type):
         """カテゴリー選択ダイアログを表示"""
         try:
@@ -1784,6 +1825,9 @@ class DesignView(QWidget):
                                 equipment_id = slot_data.get("equipment_id")
                                 if equipment_id:
                                     self.set_equipment_selection(slot_id, equipment_id)
+
+                    if not design_data.get("internal_slots"):
+                        self.ensure_default_internal_slots()
 
                     # 性能表示を更新
                     # self.update_stats()


### PR DESCRIPTION
## Summary
- add method to create default internal slots for radar, sonar, and fire control
- automatically insert these slots when selecting a hull or when loading designs without internal slot data
- record work in `DEVELOPMENT_LOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f697765588322a5df17dd532c2907